### PR TITLE
Added global page segmentation mode configuration to preferences & minor improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 *.iml
 target/
 /gui/hs_err_pid*.log
+**/.vscode
+**/.settings
+**/.classpath
+**/.project

--- a/gui/src/main/java/de/vorb/tesseract/gui/view/dialogs/PreferencesDialog.java
+++ b/gui/src/main/java/de/vorb/tesseract/gui/view/dialogs/PreferencesDialog.java
@@ -26,15 +26,35 @@ import java.util.prefs.Preferences;
 public class PreferencesDialog extends JDialog {
     private static final long serialVersionUID = 1L;
 
+    private static final String[] PSM_MODES = {
+            "0 - PSM_OSD_ONLY",
+            "1 - PSM_AUTO_OSD",
+            "2 - PSM_AUTO_ONLY",
+            "3 - (DEFAULT) PSM_AUTO",
+            "4 - PSM_SINGLE_COLUMN",
+            "5 - PSM_SINGLE_BLOCK_VERT_TEXT",
+            "6 - PSM_SINGLE_BLOCK",
+            "7 - PSM_SINGLE_LINE",
+            "8 - PSM_SINGLE_WORD",
+            "9 - PSM_CIRCLE_WORD",
+            "10 - PSM_SINGLE_CHAR",
+            "11 - PSM_SPARSE_TEXT",
+            "12 - PSM_SPARSE_TEXT_OSD",
+            "13 - PSM_RAW_LINE",
+    };
+    public static final int DEFAULT_PSM_MODE = 3;
+
     public static final String KEY_LANGDATA_DIR = "langdata_dir";
     public static final String KEY_RENDERING_FONT = "rendering_font";
     public static final String KEY_EDITOR_FONT = "editor_font";
+    public static final String KEY_PAGE_SEG_MODE = "page_seg_mode";
 
     private final JPanel contentPanel = new JPanel();
     private JTextField tfLangdataDir;
 
     private final JComboBox<String> comboRenderingFont;
     private final JComboBox<String> comboEditorFont;
+    private final JComboBox<String> comboPageSegMode;
 
     private ResultState resultState = ResultState.CANCEL;
 
@@ -134,48 +154,20 @@ public class PreferencesDialog extends JDialog {
         final GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
         final String[] availableFontFamilyNames = graphicsEnvironment.getAvailableFontFamilyNames();
 
-        {
-            JLabel lblRenderingFont = new JLabel("Rendering font:");
-            GridBagConstraints gbc_lblRenderingFont = new GridBagConstraints();
-            gbc_lblRenderingFont.anchor = GridBagConstraints.EAST;
-            gbc_lblRenderingFont.insets = new Insets(0, 0, 0, 5);
-            gbc_lblRenderingFont.gridx = 0;
-            gbc_lblRenderingFont.gridy = 2;
-            contentPanel.add(lblRenderingFont, gbc_lblRenderingFont);
-        }
-        {
-            comboRenderingFont = new JComboBox<>();
-            GridBagConstraints gbc_comboRenderingFont = new GridBagConstraints();
-            gbc_comboRenderingFont.insets = new Insets(0, 0, 0, 5);
-            gbc_comboRenderingFont.fill = GridBagConstraints.HORIZONTAL;
-            gbc_comboRenderingFont.gridx = 1;
-            gbc_comboRenderingFont.gridy = 2;
-            contentPanel.add(comboRenderingFont, gbc_comboRenderingFont);
+        // Rendering font
+        addGridLabel(0, 2, "Rendering font:");
+        final String initialFontFamilyName = pref.get(PreferencesDialog.KEY_EDITOR_FONT, Font.SANS_SERIF);
+        comboRenderingFont = createGridComboBox(1, 2, availableFontFamilyNames, initialFontFamilyName);
 
-            Arrays.stream(availableFontFamilyNames).forEach(comboRenderingFont::addItem);
-            comboRenderingFont.setSelectedItem(pref.get(PreferencesDialog.KEY_RENDERING_FONT, Font.SANS_SERIF));
-        }
-        {
-            JLabel lblEditorFont = new JLabel("Editor font:");
-            GridBagConstraints gbc_lblEditorFont = new GridBagConstraints();
-            gbc_lblEditorFont.anchor = GridBagConstraints.EAST;
-            gbc_lblEditorFont.insets = new Insets(0, 0, 0, 5);
-            gbc_lblEditorFont.gridx = 0;
-            gbc_lblEditorFont.gridy = 3;
-            contentPanel.add(lblEditorFont, gbc_lblEditorFont);
-        }
-        {
-            comboEditorFont = new JComboBox<>();
-            GridBagConstraints gbc_comboEditorFont = new GridBagConstraints();
-            gbc_comboEditorFont.insets = new Insets(0, 0, 0, 5);
-            gbc_comboEditorFont.fill = GridBagConstraints.HORIZONTAL;
-            gbc_comboEditorFont.gridx = 1;
-            gbc_comboEditorFont.gridy = 3;
-            contentPanel.add(comboEditorFont, gbc_comboEditorFont);
+        // Editor font
+        addGridLabel(0, 3, "Editor font:");
+        final String initialEditorFontFamilyName = pref.get(PreferencesDialog.KEY_RENDERING_FONT, Font.MONOSPACED);
+        comboEditorFont = createGridComboBox(1, 3, availableFontFamilyNames, initialEditorFontFamilyName);
 
-            Arrays.stream(availableFontFamilyNames).forEach(comboEditorFont::addItem);
-            comboEditorFont.setSelectedItem(pref.get(PreferencesDialog.KEY_EDITOR_FONT, Font.MONOSPACED));
-        }
+        // Page Segmentation Modes
+        addGridLabel(0, 4, "Page Segmentation Mode:");
+        final int pageSegMode = pref.getInt(PreferencesDialog.KEY_PAGE_SEG_MODE, DEFAULT_PSM_MODE);
+        comboPageSegMode = createGridComboBox(1, 4, PSM_MODES, PSM_MODES[pageSegMode]);
 
         pack();
         setMinimumSize(getSize());
@@ -197,9 +189,39 @@ public class PreferencesDialog extends JDialog {
         return comboEditorFont;
     }
 
+    public int getPageSegmentationMode() {
+        return comboPageSegMode.getSelectedIndex();
+    }
+
     public ResultState showPreferencesDialog(Component parent) {
         setLocationRelativeTo(parent);
         setVisible(true);
         return resultState;
     }
+
+    private Component addGridLabel(int gridX, int gridY, String label) {
+        JLabel jLabel = new JLabel(label);
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.anchor = GridBagConstraints.EAST;
+        constraints.insets = new Insets(0, 0, 0, 5);
+        constraints.gridx = gridX;
+        constraints.gridy = gridY;
+        contentPanel.add(jLabel, constraints);
+        return jLabel;
+    }
+
+    private <T> JComboBox<T> createGridComboBox(int gridX, int gridY, T[] options, T selectedItem) {
+        JComboBox<T> jComboBox = new JComboBox<>();
+        GridBagConstraints constraints = new GridBagConstraints();
+        constraints.insets = new Insets(0, 0, 0, 5);
+        constraints.fill = GridBagConstraints.HORIZONTAL;
+        constraints.gridx = gridX;
+        constraints.gridy = gridY;
+        contentPanel.add(jComboBox, constraints);
+
+        Arrays.stream(options).forEach(jComboBox::addItem);
+        jComboBox.setSelectedItem(selectedItem);
+        return jComboBox;
+    }
+
 }

--- a/gui/src/main/java/de/vorb/tesseract/gui/work/PageRecognitionProducer.java
+++ b/gui/src/main/java/de/vorb/tesseract/gui/work/PageRecognitionProducer.java
@@ -30,6 +30,7 @@ public class PageRecognitionProducer extends RecognitionProducer {
 
     private final TesseractController controller;
     private final HashMap<String, String> variables = new HashMap<>();
+    private int pageSegmentationMode = tesseract.PSM_AUTO;
 
     public PageRecognitionProducer(TesseractController controller,
             Path tessdataDir, String trainingFile) {
@@ -67,7 +68,7 @@ public class PageRecognitionProducer extends RecognitionProducer {
                 tesseract.OEM_DEFAULT);
 
         // set page segmentation mode
-        tesseract.TessBaseAPISetPageSegMode(getHandle(), tesseract.PSM_AUTO);
+        tesseract.TessBaseAPISetPageSegMode(getHandle(), pageSegmentationMode);
 
         // set variables
         for (Entry<String, String> var : variables.entrySet()) {
@@ -78,6 +79,11 @@ public class PageRecognitionProducer extends RecognitionProducer {
     @Override
     public void close() throws IOException {
         tesseract.TessBaseAPIDelete(getHandle());
+    }
+
+    public void setPageSegmentationMode(int pageSegmentationMode) {
+        this.pageSegmentationMode = pageSegmentationMode;
+        tesseract.TessBaseAPISetPageSegMode(getHandle(), pageSegmentationMode);
     }
 
     public void loadImage(Path imageFile) {

--- a/ocrevalUAtion/pom.xml
+++ b/ocrevalUAtion/pom.xml
@@ -29,7 +29,7 @@
     </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>1.7</jdk.version>
     </properties>
     <build>
         <!--finalName>ocrevaluation</finalName-->
@@ -39,8 +39,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <showDeprecation>true</showDeprecation>
                 </configuration>
             </plugin>
@@ -226,6 +226,11 @@
             <artifactId>tika-parsers</artifactId>
             <version>1.4</version>
             <type>jar</type>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/tools/src/main/java/de/vorb/tesseract/tools/preprocessing/binarization/BinarizationUtilities.java
+++ b/tools/src/main/java/de/vorb/tesseract/tools/preprocessing/binarization/BinarizationUtilities.java
@@ -25,6 +25,7 @@ public final class BinarizationUtilities {
             case BufferedImage.TYPE_INT_RGB:
             case BufferedImage.TYPE_BYTE_INDEXED:
             case BufferedImage.TYPE_3BYTE_BGR:
+            case BufferedImage.TYPE_4BYTE_ABGR:
                 grayscale = new BufferedImage(image.getWidth(), image.getHeight(), BufferedImage.TYPE_BYTE_GRAY);
                 RGB_TO_GRAYSCALE.filter(image, grayscale);
                 break;


### PR DESCRIPTION
**Added global page segmentation mode configuration to preferences**
- Added Visual Studio code and Eclipse project files to .gitignore
- Added support for images with 4 byte RGBA color components (this was a silent error)
- Updated source compatibility from Java 6 to Java 7 and added alternate Java EE API specifically for Java 11

For users that need to configure a different PSM in the underlying tesseract engine, this allows them to persist and apply the configuration on the fly. 

Notes: 
- This is a destructive action; if you are performing box editing this will cause the `RecognitionWorker` to execute again which _will_ re-render all page model components. This behavior could be improved by allowing the user to confirm before applying changes, removing the behavior altogether, or perhaps moving the preference into relevant controls pane (common pane?).
- Having a per-image configuration may be desirable
- More on Java 11 via [StackOverflow](https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist): https://stackoverflow.com/questions/52502189/java-11-package-javax-xml-bind-does-not-exist

<img width="676" alt="image" src="https://user-images.githubusercontent.com/1811147/96244331-8265e300-0fd8-11eb-8c3d-698c66e31329.png">
