### PR TITLE
Remove redundant dependencies

### DIFF
--- a/ocrevalUAtion/pom.xml
+++ b/ocrevalUAtion/pom.xml
@@ -226,6 +226,24 @@
             <artifactId>tika-parsers</artifactId>
             <version>1.4</version>
             <type>jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.gagravarr</groupId>
+                    <artifactId>vorbis-java-core</artifactId>
+                </exclusion>  
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion> 
+                <exclusion>
+                    <groupId>rome</groupId>
+                    <artifactId>rome</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
@pvorb Hi, I am a user of project **_de.vorb.tesseract:ocrevalUAtion:0.3.0-SNAPSHOT_**. I found that its pom file introduced **_45_** dependencies. However, among them, **_6_** libraries (**_13%_**) have not been used by your project (the redundant dependencies are listed below). Reduce these useless dependencies can help prevent conflicts between library versions. MeanWhile, it can minimize the total added size to projects. It can also help enable advanced scenarios for users of your package. 
This PR helps **_de.vorb.tesseract:ocrevalUAtion:0.3.0-SNAPSHOT_** lose weight :) I have tested the revised configuration in my local environment. It is safe to remove the unused libraries.

Best regards


## Redundant dependencies----
<pre><code>
jdom:jdom:jar:1.0:compile
org.gagravarr:vorbis-java-core:jar:tests:0.1:test,provided
xml-apis:xml-apis:jar:1.3.03:compile
rome:rome:jar:0.9:compile
org.gagravarr:vorbis-java-core:jar:0.1:compile
org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
</code></pre>
## Outdated dependencies
xml-apis:xml-apis:1.3.03 (**_6318_** days without maintenance)
org.gagravarr:vorbis-java-core:0.1 (**_4193_** days without maintenance)