### PR TITLE
Add note about Usage page on Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ by Paul Vorbach (German).
 
 [![Donate with PayPal](https://www.paypalobjects.com/en_US/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=LF8T2JP2YUUUE)
 
+## Usage
+Basic usage is documented on [our wiki page](https://github.com/tesseract4java/tesseract4java/wiki/Usage)
 
 ## Download
 


### PR DESCRIPTION
- A link to the Wiki from the README would be useful, it took me over 1 hour to figure this out by happening to have an issue, searching the issues, and noting the wiki page referenced in an existing issue.  Having this basic link would have saved time.